### PR TITLE
Error with Default Image Link fixed

### DIFF
--- a/MAJOR PROJECT/models/listing.js
+++ b/MAJOR PROJECT/models/listing.js
@@ -1,24 +1,23 @@
 const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 
+let defaultLink =
+  "https://images.unsplash.com/photo-1470252649378-9c29740c9fa8?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
+
 const listingSchema = new Schema({
-    title: {
-        type: String,
-        required: true,
-    },
-    description: String,
-    image: {
-        type: String,
-        default: 
-        "https://unsplash.com/photos/trees-under-cloudy-sky-during-sunset--G3rw6Y02D0",
-        set: (v) => 
-          v === ""
-          ? "https://unsplash.com/photos/trees-under-cloudy-sky-during-sunset--G3rw6Y02D0"
-          : v,
-    },
-    price: Number,
-    location: String,
-    country: String,
+  title: {
+    type: String,
+    required: true,
+  },
+  description: String,
+  image: {
+    type: String,
+    default: defaultLink,
+    set: (v) => (v === "" ? defaultLink : v),
+  },
+  price: Number,
+  location: String,
+  country: String,
 });
 
 const Listing = mongoose.model("Listing", listingSchema);


### PR DESCRIPTION
The link of the default image was set to the webpage on Unsplash where the image was listed. 
Updated the default link to the actual link of the image.

To get the image link of any image, follow these steps:

1. Open the webpage where the image is listed.
2. Right-click on the image and select "Copy Image Link"